### PR TITLE
prove to not touch T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG in php8.1

### DIFF
--- a/src/ClassReferenceFinder.php
+++ b/src/ClassReferenceFinder.php
@@ -107,7 +107,8 @@ class ClassReferenceFinder
                 //isset($classes[$c]) && $c++;
                 self::forward();
                 continue;
-            } elseif ($t === T_WHITESPACE || $t === '&' || $t === T_COMMENT) {
+            } elseif ($t === T_WHITESPACE || $t === '&' || $t === T_COMMENT || $t === 403) {
+		// 403 is code name T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG in php8.1
                 // We do not want to keep track of
                 // white spaces or collect them
                 continue;


### PR DESCRIPTION
& is 403 or T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG in php8.1
it should be ignored in the ClassReferenceFinder::process method 
but in the old PHP version, we don't have this Const I used  403 instead of code name T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG

https://github.com/imanghafoori1/laravel-microscope/issues/170