### PR TITLE
Fixed ClassMethods

### DIFF
--- a/tests/InterfaceMethodsTest.php
+++ b/tests/InterfaceMethodsTest.php
@@ -47,6 +47,7 @@ class InterfaceMethodsTest extends BaseTestClass
 
         $this->assertNull($methods[0]['returnType']);
         $this->assertEquals('test', $methods[4]['returnType'][0][1]);
+        $this->assertEquals('PHPUnit\Framework\IncompleteTest', $methods[4]['returnType'][1][1]);
         $this->assertEquals('string', $methods[5]['returnType'][0][1]);
         $this->assertEquals('bool', $methods[6]['returnType'][0][1]);
         $this->assertEquals('int', $methods[7]['returnType'][0][1]);

--- a/tests/stubs/interface_sample.stub
+++ b/tests/stubs/interface_sample.stub
@@ -24,7 +24,7 @@ interface interface_sample extends IncompleteTest {
     static function method_3();
 
     // methods with returns type
-    public function method_4(): test;
+    public function method_4(): test|IncompleteTest;
 
     public function method_5(): string;
 


### PR DESCRIPTION
![image](https://github.com/imanghafoori1/php_token_analyzer/assets/49164621/02410fea-1145-42c9-8aaa-cbc243c2343f)

In this example, the return type for Arrayable should be Illuminate\Contracts\Support\Arrayable, but before these changes, the return type was Arrayable.