### PR TITLE
Read refs from invalid docBlocks

### DIFF
--- a/src/ClassReferenceFinder.php
+++ b/src/ClassReferenceFinder.php
@@ -117,7 +117,15 @@ class ClassReferenceFinder
                     new Location($token[2], 4)
                 );
             } catch (RuntimeException $e) {
-                continue;
+                try {
+                    $doc = $docblock->create(
+                        self::normalizeDocblockContent($token[1]),
+                        new Context('q1w23e4rt___ffff000'),
+                        new Location($token[2], 4)
+                    );
+                }catch (RuntimeException $e) {
+                    continue;
+                }
             }
 
             $refs = array_merge($refs, self::getRefsInDocblock($doc));
@@ -190,7 +198,6 @@ class ClassReferenceFinder
             $ref = str_replace('[]', '', $ref);
             $ref = trim($ref, '<>');
             $ref && self::shouldBeCollected($ref) && $allRefs[] = [
-                // Remove "?" from nullable references like: "?User"
                 'class' => str_replace('\\q1w23e4rt___ffff000\\', '', $ref),
                 'line' => $line,
             ];
@@ -318,5 +325,18 @@ class ClassReferenceFinder
         }
 
         return $refs;
+    }
+
+    /*
+     * This method corrects the following invalid docBlocks
+     * @param Empty<>
+     * @param array<mixed, string>
+     * @var ?Test|?User
+     */
+    private static function normalizeDocblockContent(string $docblock)
+    {
+        $docblock = str_replace('mixed', 'string', $docblock);
+
+        return str_replace(['?', '<>'], '', $docblock);
     }
 }

--- a/tests/ClassReferencesProcessTest.php
+++ b/tests/ClassReferencesProcessTest.php
@@ -80,6 +80,9 @@ class ClassReferencesProcessTest extends BaseTestClass
         $this->assertEquals( ["class" => "Collection", "line" => 36], $output[15]);
         $this->assertEquals( ["class" => "Test", "line" => 36], $output[16]);
         $this->assertEquals( ["class" => "User", "line" => 36], $output[17]);
+        $this->assertEquals( ["class" => "Empty", "line" => 43], $output[18]);
+        $this->assertEquals( ["class" => "MixArray", "line" => 43], $output[19]);
+        $this->assertEquals( ["class" => "User", "line" => 43], $output[20]);
     }
 
     /** @test */

--- a/tests/stubs/doc_block_ref.stub
+++ b/tests/stubs/doc_block_ref.stub
@@ -39,4 +39,12 @@ class D {
      * @var Collection<Test<array<User>>> $users
      */
     private $products;
+
+    /**
+     * Invalid docBlocks
+     *
+     * @param Empty<> $n
+     * @param MixArray|array<mixed, string> $n
+     * @param array<mixed>|?User $n
+     */
 }


### PR DESCRIPTION
This changes corrects the following invalid docBlocks

```php
    /*
     * @param Empty<>
     * @param array<mixed, string>
     * @var ?Test|?User
     */
```