### PR TITLE
Read refs from invalid doc block tags

### DIFF
--- a/src/ClassReferenceFinder.php
+++ b/src/ClassReferenceFinder.php
@@ -47,6 +47,33 @@ class ClassReferenceFinder
         Keywords\TAttribute::class,
     ];
 
+    public static $ignoreRefs = [
+        'array',
+        'bool',
+        'callable',
+        'false',
+        'float',
+        'int',
+        'iterable',
+        'mixed',
+        'never',
+        'null',
+        'object',
+        'private',
+        'public',
+        'protected',
+        'parent',
+        'static',
+        'self',
+        'string',
+        'true',
+        'void',
+        '::',
+        'list',
+        'scalar',
+        'resource',
+    ];
+
     /**
      * @param  array  $tokens
      *
@@ -71,32 +98,8 @@ class ClassReferenceFinder
 
     public static function isBuiltinType($token)
     {
-        return \in_array(strtolower($token[1]), [
-            'array',
-            'bool',
-            'callable',
-            'false',
-            'float',
-            'int',
-            'iterable',
-            'mixed',
-            'never',
-            'null',
-            'object',
-            'private',
-            'public',
-            'protected',
-            'parent',
-            'static',
-            'self',
-            'string',
-            'true',
-            'void',
-            '::',
-            'list',
-            'scalar',
-            'resource',
-        ], true) || \in_array($token[0], [T_READONLY]);
+        return \in_array(strtolower($token[1]), self::$ignoreRefs, true)
+            || \in_array($token[0], [T_READONLY]);
     }
 
     public static function getExpandedDocblockRefs($imports, $docblockRefs, $namespace)

--- a/src/ClassReferenceFinder.php
+++ b/src/ClassReferenceFinder.php
@@ -72,6 +72,7 @@ class ClassReferenceFinder
         'list',
         'scalar',
         'resource',
+        'is',
     ];
 
     /**

--- a/src/DocblockReader.php
+++ b/src/DocblockReader.php
@@ -11,12 +11,7 @@ use RuntimeException;
 
 class DocblockReader
 {
-    private static $ignoreTemplateRefs = [
-        'array-key',
-        'object',
-    ];
-
-    public static function readRefsInDocblocks($tokens)
+    public static function readRefsInDocblocks($tokens): array
     {
         ClassReferenceFinder::defineConstants();
         $docblock = DocBlockFactory::createInstance();
@@ -154,7 +149,7 @@ class DocblockReader
                 continue;
             }
             $partsOfName = explode(' of ', $tagName);
-            if (!isset($partsOfName[1]) || in_array($partsOfName[1], self::$ignoreTemplateRefs)) {
+            if (! isset($partsOfName[1]) || ! self::shouldBeCollected($partsOfName[1])) {
                 continue;
             }
 
@@ -182,7 +177,7 @@ class DocblockReader
         return $mixins;
     }
 
-    private static function readMethodTag(DocBlock $docblock, int $line)
+    private static function readMethodTag(DocBlock $docblock, int $line): array
     {
         $refs = [];
 
@@ -239,7 +234,7 @@ class DocblockReader
         return explode('|', $ref);
     }
 
-    private static function shouldBeCollected(string $ref)
+    private static function shouldBeCollected(string $ref): bool
     {
         return ! ClassReferenceFinder::isBuiltinType([0, $ref]) && ! Str::contains($ref, ['<', '>', '$', ':', '(', ')', '{', '}', '-']);
     }

--- a/src/DocblockReader.php
+++ b/src/DocblockReader.php
@@ -28,8 +28,8 @@ class DocblockReader
                  * Extends tag was replaced with var
                  * Because we don't have phpDocumentor\Reflection\Types\Collection in the extends tag
                  */
-                $content = str_replace('@extends', '@var', $content);
-                $doc = self::read($docblock, str_replace('?', '', $content), $line);
+                $content = \str_replace('@extends', '@var', $content);
+                $doc = self::read($docblock, \str_replace('?', '', $content), $line);
             } catch (RuntimeException $e) {
                 try {
                     $doc = self::read($docblock, self::normalizeDocblockContent($content), $line);
@@ -39,13 +39,13 @@ class DocblockReader
             }
 
             [$tTemplates, $tRefs] = self::parseTemplatesInDocblock($doc);
-            $refs = array_merge($refs, $tRefs, self::getRefsInDocblock($doc));
-            $atTemplate = array_merge($atTemplate, $tTemplates);
+            $refs = \array_merge($refs, $tRefs, self::getRefsInDocblock($doc));
+            $atTemplate = \array_merge($atTemplate, $tTemplates);
         }
 
         // use array_values for reset array keys.
-        return array_values(array_filter($refs, function ($ref) use ($atTemplate) {
-            return ! in_array($ref['class'], $atTemplate);
+        return \array_values(\array_filter($refs, function ($ref) use ($atTemplate) {
+            return ! \in_array($ref['class'], $atTemplate);
         }));
     }
 
@@ -66,18 +66,20 @@ class DocblockReader
      */
     private static function normalizeDocblockContent(string $docblock)
     {
-        $docblock = str_replace('mixed', 'string', $docblock);
+        $docblock = \str_replace('mixed', 'string', $docblock);
 
-        return str_replace(['?', '<>'], '', $docblock);
+        return \str_replace(['?', '<>'], '', $docblock);
     }
 
     private static function addRef($refsInDocBlock, int $line, array $allRefs)
     {
         foreach ($refsInDocBlock as $ref) {
-            $ref = str_replace('[]', '', $ref);
-            $ref = trim($ref, '<>');
+            $ref = \str_replace('[]', '', $ref);
+            $ref = \trim($ref, '<>');
+            // For parse this "ColumnCase::LOWER"
+            $ref = \strtok($ref, '::');
             $ref && self::shouldBeCollected($ref) && $allRefs[] = [
-                'class' => str_replace('\\q1w23e4rt___ffff000\\', '', $ref),
+                'class' => \str_replace('\\q1w23e4rt___ffff000\\', '', $ref),
                 'line' => $line,
             ];
         }
@@ -91,7 +93,7 @@ class DocblockReader
 
         $readRef = self::getRefReader($docblock, $line);
 
-        return array_merge(
+        return \array_merge(
             self::readMethodTag($docblock, $line),
             self::getMixins($docblock, $line),
             $readRef('param'),
@@ -107,7 +109,7 @@ class DocblockReader
 
     private static function parseTemplatesInDocblock(DocBlock $docblock): array
     {
-        if (! method_exists($docblock, 'getTags')) {
+        if (! \method_exists($docblock, 'getTags')) {
             return [[], []];
         }
 
@@ -130,7 +132,7 @@ class DocblockReader
             if (empty($tagName)) {
                 continue;
             }
-            $atTemplate[] = explode(' of ', $tagName)[0];
+            $atTemplate[] = \explode(' of ', $tagName)[0];
         }
 
         return $atTemplate;
@@ -148,7 +150,7 @@ class DocblockReader
             if (empty($tagName)) {
                 continue;
             }
-            $partsOfName = explode(' of ', $tagName);
+            $partsOfName = \explode(' of ', $tagName);
             if (! isset($partsOfName[1]) || ! self::shouldBeCollected($partsOfName[1])) {
                 continue;
             }
@@ -170,7 +172,7 @@ class DocblockReader
 
             $mixins[] = [
                 'line' => $line,
-                'class' => strtok($desc->__toString(), ' '),
+                'class' => \strtok($desc->__toString(), ' '),
             ];
         }
 
@@ -184,9 +186,9 @@ class DocblockReader
         foreach ($docblock->getTagsByName('method') as $method) {
             $refs = self::addRef(self::explode($method->getReturnType()), $line, $refs);
 
-            $methodName = method_exists($method, 'getParameters') ? 'getParameters' : 'getArguments';
+            $methodName = \method_exists($method, 'getParameters') ? 'getParameters' : 'getArguments';
             foreach ($method->$methodName() as $argument) {
-                $_refs = self::explode(str_replace('?', '', (string) $argument['type']));
+                $_refs = self::explode(\str_replace('?', '', (string) $argument['type']));
                 $refs = self::addRef($_refs, $line, $refs);
             }
         }
@@ -199,6 +201,10 @@ class DocblockReader
         return function ($tagName) use ($docblock, $line) {
             $refs = [];
             foreach ($docblock->getTagsByName($tagName) as $ref) {
+                if ($ref instanceof DocBlock\Tags\InvalidTag) {
+                    $refs = self::findRefsInvalidTags($ref, $line, $refs);
+                    continue;
+                }
                 $refs = self::findRefsTags($ref, $line, $refs);
             }
 
@@ -208,34 +214,47 @@ class DocblockReader
 
     private static function findRefsTags($types, int $line, array $refs): array
     {
-        if (! method_exists($types, 'getType') && ! method_exists($types, 'getValueType') && ! method_exists($types, 'getFqsen')) {
+        if (! \method_exists($types, 'getType')
+            && ! \method_exists($types, 'getValueType')
+            && ! \method_exists($types, 'getFqsen')) {
             return self::addRef(self::explode($types), $line, $refs);
         }
 
-        if (method_exists($types, 'getFqsen')) {
+        if (\method_exists($types, 'getFqsen')) {
             $refs = self::addRef(self::explode($types->getFqsen()), $line, $refs);
         }
 
-        if (method_exists($types, 'getType') && ($type = $types->getType())) {
+        if (\method_exists($types, 'getType') && ($type = $types->getType())) {
             return self::findRefsTags($type, $line, $refs);
         }
 
-        if (method_exists($types, 'getValueType') && ($types = $types->getValueType())) {
+        if (\method_exists($types, 'getValueType') && ($types = $types->getValueType())) {
             return self::findRefsTags($types, $line, $refs);
         }
 
         return $refs;
     }
 
+    private static function findRefsInvalidTags($types, int $line, array $refs): array
+    {
+        $body = \trim($types->__toString(), '(){}[]');
+        foreach (\array_filter(\explode(' ', $body)) as $ref) {
+            $refs = self::addRef(self::explode($ref), $line, $refs);
+        }
+
+        return \array_unique($refs, SORT_REGULAR);
+    }
+
     public static function explode($ref): array
     {
-        $ref = str_replace([',', '&'], '|', (string) $ref);
+        $ref = \str_replace([',', '&'], '|', (string) $ref);
 
-        return explode('|', $ref);
+        return \explode('|', $ref);
     }
 
     private static function shouldBeCollected(string $ref): bool
     {
-        return ! ClassReferenceFinder::isBuiltinType([0, $ref]) && ! Str::contains($ref, ['<', '>', '$', ':', '(', ')', '{', '}', '-']);
+        return ! ClassReferenceFinder::isBuiltinType([0, $ref])
+            && ! Str::contains($ref, ['<', '>', '$', ':', '(', ')', '{', '}', '-']);
     }
 }

--- a/tests/DocblockReferencesProcessTest.php
+++ b/tests/DocblockReferencesProcessTest.php
@@ -57,4 +57,18 @@ class DocblockReferencesProcessTest extends BaseTestClass
         $this->assertEquals($excepted, $output);
         $this->assertCount(1, $output);
     }
+
+    /** @test */
+    public function can_detect_invalid_tags()
+    {
+        $tokens = $this->getTokens(__DIR__ . '/stubs/docblocks/invalid_tags.stub');
+        $output = DocblockReader::readRefsInDocblocks($tokens);
+
+        $excepted = [
+            ['line' => 5, 'class' => 'DateTimeInterface'],
+            ['line' => 16, 'class' => 'ColumnCase'],
+        ];
+
+        $this->assertEquals($excepted, $output);
+    }
 }

--- a/tests/stubs/docblocks/invalid_tags.stub
+++ b/tests/stubs/docblocks/invalid_tags.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace A1\A2;
+
+/**
+ * {@inheritDoc}
+ *
+  * @param T $value
+ *
+ * @return (T is null ? null : DateTimeInterface)
+ *
+ * @template T
+ */
+class Test {
+
+    /** @var 0|ColumnCase::LOWER|ColumnCase::UPPER */
+    private int $case;
+
+}


### PR DESCRIPTION
Sample invalid tags

```
/**
 * {@inheritDoc}
 *
  * @param T $value
 *
 * @return (T is null ? null : DateTimeInterface)
 *
 * @template T
 */
 ```
 ```
  /** @var 0|ColumnCase::LOWER|ColumnCase::UPPER */
    private int $case;
```
 