### PR TITLE
Read refs from description doc blocks

### DIFF
--- a/src/DocblockReader.php
+++ b/src/DocblockReader.php
@@ -96,6 +96,7 @@ class DocblockReader
         $readRef = self::getRefReader($docblock, $line);
 
         return \array_merge(
+            self::readDescriptionRefs($docblock, $line),
             self::readMethodTag($docblock, $line),
             self::getMixins($docblock, $line),
             $readRef('param'),
@@ -200,7 +201,7 @@ class DocblockReader
 
     private static function getRefReader(DocBlock $docblock, int $line): Closure
     {
-        return function ($tagName) use ($docblock, $line) {
+        return function ($tagName) use ($docblock, $line): array {
             $refs = [];
             foreach ($docblock->getTagsByName($tagName) as $ref) {
                 $refs = self::findRefsTags($ref, $line, $refs);
@@ -208,6 +209,20 @@ class DocblockReader
 
             return $refs;
         };
+    }
+
+    private static function readDescriptionRefs(DocBlock $docblock, int $line): array
+    {
+        $description = $docblock->getDescription();
+
+        $refs = [];
+        if (\method_exists($description, 'getTags')) {
+            foreach ($docblock->getDescription()->getTags() as $tag) {
+                $refs = self::findRefsTags($tag, $line, $refs);
+            }
+        }
+
+        return $refs;
     }
 
     private static function findRefsTags($types, int $line, array $refs): array

--- a/tests/DocblockReferencesProcessTest.php
+++ b/tests/DocblockReferencesProcessTest.php
@@ -42,6 +42,10 @@ class DocblockReferencesProcessTest extends BaseTestClass
         $this->assertEquals( ["class" => "Generator", "line" => 62], $output[$i++]);
         $this->assertEquals( ["class" => "ColumnCase", "line" => 67], $output[$i++]);
         $this->assertEquals( ["class" => "ColumnCase", "line" => 67], $output[$i++]);
+        $this->assertEquals( ["class" => "Statement", "line" => 70], $output[$i++]);
+        $this->assertEquals( ["class" => "Cat", "line" => 70], $output[$i++]);
+        $this->assertEquals( ["class" => "Yellow", "line" => 70], $output[$i++]);
+        $this->assertEquals( ["class" => "LaraCast", "line" => 70], $output[$i++]);
 
         $this->assertCount($i, $output);
     }

--- a/tests/stubs/docblocks/doc_block_ref.stub
+++ b/tests/stubs/docblocks/doc_block_ref.stub
@@ -66,4 +66,13 @@ class D {
 
      /** @var 0|ColumnCase::LOWER|ColumnCase::UPPER */
      private int $case;
+
+     /**
+      * Creates a new named parameter and bind the value $value to it.
+      *
+      * This method provides a shortcut for {@see Statement::bindValue()}
+      * when using prepared statements. {@var Cat $cat}
+      * test empty {@return list<mixed>|false}
+      * test multiple {@var Yellow<list<array<LaraCast>>> $users}
+      */
 }


### PR DESCRIPTION
Sample:

```
/**
 * Creates a new named parameter and bind the value $value to it.
 *
 * This method provides a shortcut for {@see Statement::bindValue()}
 * when using prepared statements.
 */
```