### PR TITLE
Fixed doc block reader

### DIFF
--- a/src/DocblockReader.php
+++ b/src/DocblockReader.php
@@ -164,7 +164,12 @@ class DocblockReader
                 continue;
             }
 
-            $refs[] = ['line' => $line, 'class' => $partsOfName[1]];
+            $refClass = trim(strtok($partsOfName[1], '='));
+            if (! self::shouldBeCollected($refClass)) {
+                continue;
+            }
+
+            $refs[] = ['line' => $line, 'class' => $refClass];
         }
 
         return $refs;

--- a/tests/DocblockReferencesProcessTest.php
+++ b/tests/DocblockReferencesProcessTest.php
@@ -13,39 +13,39 @@ class DocblockReferencesProcessTest extends BaseTestClass
         $output = DocblockReader::readRefsInDocblocks($tokens);
         $i = 0;
 
-        $this->assertEquals( ["class" => "Eloquent", "line" => 6], $output[$i++]);
-        $this->assertEquals( ["class" => "\App\Eloquent", "line" => 6], $output[$i++]);
-        $this->assertEquals( ["class" => "A", "line" => 6], $output[$i++]);
-        $this->assertEquals( ["class" => "Logger", "line" => 12], $output[$i++]);
-        $this->assertEquals( ["class" => "Hello", "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => "Hello3", "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => "Hello2", "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => "ArrayIterator", "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => "Returny", "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => 'DOMElement', "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => "\Exception", "line" => 17], $output[$i++]);
-        $this->assertEquals( ["class" => "User", "line" => 29], $output[$i++]);
-        $this->assertEquals( ["class" => "Test", "line" => 34], $output[$i++]);
-        $this->assertEquals( ["class" => "Products", "line" => 39], $output[$i++]);
-        $this->assertEquals( ["class" => "Product", "line" => 39], $output[$i++]);
-        $this->assertEquals( ["class" => "Collection", "line" => 39], $output[$i++]);
-        $this->assertEquals( ["class" => "User", "line" => 39], $output[$i++]);
-        $this->assertEquals( ["class" => "Collection", "line" => 39], $output[$i++]);
-        $this->assertEquals( ["class" => "Test", "line" => 39], $output[$i++]);
-        $this->assertEquals( ["class" => "User2", "line" => 39], $output[$i++]);
-        //$this->assertEquals( ["class" => "MixArray", "line" => 46], $output[$i++]);
-        //$this->assertEquals( ["class" => "User", "line" => 46], $output[$i++]);
-        $this->assertEquals( ["class" => "AbstractSchemaManager", "line" => 62], $output[$i++]);
-        $this->assertEquals( ["class" => "SQLServerPlatform", "line" => 62], $output[$i++]);
-        $this->assertEquals( ["class" => "MockObject", "line" => 62], $output[$i++]);
-        $this->assertEquals( ["class" => "Generator", "line" => 62], $output[$i++]);
-        $this->assertEquals( ["class" => "ColumnCase", "line" => 67], $output[$i++]);
-        $this->assertEquals( ["class" => "ColumnCase", "line" => 67], $output[$i++]);
-        $this->assertEquals( ["class" => "Statement", "line" => 70], $output[$i++]);
-        $this->assertEquals( ["class" => "Cat", "line" => 70], $output[$i++]);
-        $this->assertEquals( ["class" => "Yellow", "line" => 70], $output[$i++]);
-        $this->assertEquals( ["class" => "LaraCast", "line" => 70], $output[$i++]);
-        $this->assertEquals( ["class" => "User3", "line" => 79], $output[$i++]);
+        $this->assertEquals(['class' => 'Eloquent', 'line' => 6], $output[$i++]);
+        $this->assertEquals(['class' => '\App\Eloquent', 'line' => 6], $output[$i++]);
+        $this->assertEquals(['class' => 'A', 'line' => 6], $output[$i++]);
+        $this->assertEquals(['class' => 'Logger', 'line' => 12], $output[$i++]);
+        $this->assertEquals(['class' => 'Hello', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => 'Hello3', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => 'Hello2', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => 'ArrayIterator', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => 'Returny', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => 'DOMElement', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => '\Exception', 'line' => 17], $output[$i++]);
+        $this->assertEquals(['class' => 'User', 'line' => 29], $output[$i++]);
+        $this->assertEquals(['class' => 'Test', 'line' => 34], $output[$i++]);
+        $this->assertEquals(['class' => 'Products', 'line' => 39], $output[$i++]);
+        $this->assertEquals(['class' => 'Product', 'line' => 39], $output[$i++]);
+        $this->assertEquals(['class' => 'Collection', 'line' => 39], $output[$i++]);
+        $this->assertEquals(['class' => 'User', 'line' => 39], $output[$i++]);
+        $this->assertEquals(['class' => 'Collection', 'line' => 39], $output[$i++]);
+        $this->assertEquals(['class' => 'Test', 'line' => 39], $output[$i++]);
+        $this->assertEquals(['class' => 'User2', 'line' => 39], $output[$i++]);
+        //$this->assertEquals(['class' => 'MixArray', 'line' => 46], $output[$i++]);
+        //$this->assertEquals(['class' => 'User', 'line' => 46], $output[$i++]);
+        $this->assertEquals(['class' => 'AbstractSchemaManager', 'line' => 62], $output[$i++]);
+        $this->assertEquals(['class' => 'SQLServerPlatform', 'line' => 62], $output[$i++]);
+        $this->assertEquals(['class' => 'MockObject', 'line' => 62], $output[$i++]);
+        $this->assertEquals(['class' => 'Generator', 'line' => 62], $output[$i++]);
+        $this->assertEquals(['class' => 'ColumnCase', 'line' => 67], $output[$i++]);
+        $this->assertEquals(['class' => 'ColumnCase', 'line' => 67], $output[$i++]);
+        $this->assertEquals(['class' => 'Statement', 'line' => 70], $output[$i++]);
+        $this->assertEquals(['class' => 'Cat', 'line' => 70], $output[$i++]);
+        $this->assertEquals(['class' => 'Yellow', 'line' => 70], $output[$i++]);
+        $this->assertEquals(['class' => 'LaraCast', 'line' => 70], $output[$i++]);
+        $this->assertEquals(['class' => 'User3', 'line' => 79], $output[$i++]);
 
         $this->assertCount($i, $output);
     }
@@ -63,7 +63,7 @@ class DocblockReferencesProcessTest extends BaseTestClass
     /** @test */
     public function can_ignore_template_dockblocks()
     {
-        $tokens = $this->getTokens(__DIR__ . '/stubs/docblocks/template.stub');
+        $tokens = $this->getTokens(__DIR__.'/stubs/docblocks/template.stub');
         $output = DocblockReader::readRefsInDocblocks($tokens);
 
         $excepted = [
@@ -72,5 +72,38 @@ class DocblockReferencesProcessTest extends BaseTestClass
 
         $this->assertEquals($excepted, $output);
         $this->assertCount(1, $output);
+    }
+
+    /** @test */
+    public function can_ignore_builtin_types_and_special_keywords()
+    {
+        $tokens = $this->getTokens(__DIR__.'/stubs/docblocks/ignore_builtin_types.stub');
+        $output = DocblockReader::readRefsInDocblocks($tokens);
+
+        $expected = [
+            ['class' => 'MyValidClass', 'line' => 5],
+            ['class' => '\RuntimeException', 'line' => 5],
+            ['class' => 'AnotherClass', 'line' => 5],
+        ];
+
+        $this->assertEquals($expected, $output);
+    }
+
+    /** @test */
+    public function sanitizes_variable_names_and_handles_property_and_method_tags()
+    {
+        $tokens = $this->getTokens(__DIR__.'/stubs/docblocks/sanitize_and_more_tags.stub');
+        $output = DocblockReader::readRefsInDocblocks($tokens);
+
+        $expected = [
+            ['class' => 'User', 'line' => 5],
+            ['class' => 'Product', 'line' => 5],
+            ['class' => 'QueryBuilder', 'line' => 5],
+        ];
+
+        sort($expected);
+        sort($output);
+
+        $this->assertEquals($expected, $output);
     }
 }

--- a/tests/stubs/docblocks/ignore_builtin_types.stub
+++ b/tests/stubs/docblocks/ignore_builtin_types.stub
@@ -1,0 +1,17 @@
+<?php
+
+class IgnoresBuiltIn
+{
+    /**
+     * @var string|int|MyValidClass|bool|null
+     * @param array|callable|mixed $data
+     * @return void|self|static|never
+     * @throws \RuntimeException|object
+     * @property-read $this $instance
+     * @see AnotherClass
+     */
+    public function processData($data)
+    {
+        //
+    }
+}

--- a/tests/stubs/docblocks/sanitize_and_more_tags.stub
+++ b/tests/stubs/docblocks/sanitize_and_more_tags.stub
@@ -1,0 +1,14 @@
+<?php
+
+class SanitizesAndMore
+{
+    /**
+     * @property-read User $user The user object.
+     * @var Product|null $product
+     * @method static QueryBuilder whereStatus(string $status)
+     */
+    private function relations()
+    {
+        //
+    }
+}


### PR DESCRIPTION
https://github.com/imanghafoori1/php_token_analyzer/actions/runs/17820536745/job/50661917226?pr=38

## Summary by Sourcery

Improve extractTemplateRefs to sanitize reference class names and filter out unwanted entries

Bug Fixes:
- Prevent collecting invalid template references by trimming class names and skipping those that shouldn't be collected

Enhancements:
- Sanitize extracted template reference names by removing assignment parts before collection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docblock template reference parsing now ignores builtin/invalid entries and normalizes class names to reduce incorrect references and warnings.

* **Tests**
  * Added tests for builtin type filtering and tag sanitization to prevent regressions.
  * Added new docblock fixtures exercising complex annotations and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->